### PR TITLE
compatibility before 9.6 (at least 9.5)

### DIFF
--- a/first_last--0.1.0.sql
+++ b/first_last--0.1.0.sql
@@ -59,7 +59,7 @@ create or replace function agg_last(
     as $$
 select ( case
     when array_length( p_state, 1 ) >= p_limit
-        then p_state[(array_upper(p_state, 1) - p_limit + 2):]
+        then p_state[(array_upper(p_state, 1) - p_limit + 2):array_upper( p_state, 1 )]
     else
         p_state
     end ) || p_new_element;


### PR DESCRIPTION
Omitting the upper bound in a slice is only possible with postgresql 9.6. Unfortunately, I'm stuck with 9.5, and the current code raises a syntax error.

I think this should be enough to make the code compatible with earlier versions.

To be honest, I'm not familiar with arrays, so I may have missed something, but it seems to work.

BTW, thanks for your blog! I've learned many things on it :)